### PR TITLE
Fix the blocking scheme

### DIFF
--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,0 +1,28 @@
+TOOL  = ../OMtopogen/create_topog_refinedSampling.py
+HGRID = /home/Niki.Zadeh/safe/topogentestInput/ocean_hgrid.Merc.4deg.nc
+TARGS = ocean_topog.Merc.4deg_r3b1h1.nc \
+        ocean_topog.Merc.4deg_r3b2h1.nc \
+        ocean_topog.Merc.4deg_r3b4h1.nc
+
+all: $(TARGS)
+	cat hash.md5
+	md5sum -c hash.md5
+
+ocean_topog.Merc.4deg_r3b1h1.nc:
+	time $(TOOL) --hgridfilename $(HGRID) --nxblocks=1 --max_refine=3 --outputfilename $@ --no_changing_meta
+
+ocean_topog.Merc.4deg_r3b2h1.nc:
+	time $(TOOL) --hgridfilename $(HGRID) --nxblocks=2 --max_refine=3 --outputfilename $@ --no_changing_meta
+
+ocean_topog.Merc.4deg_r3b4h1.nc:
+	time $(TOOL) --hgridfilename $(HGRID) --nxblocks=4 --max_refine=3 --outputfilename $@ --no_changing_meta
+
+#hash.md5.gfdl-pan105: | $(TARGS)
+#	md5sum $(TARGS) > $@
+#	cat $@
+
+check:
+	md5sum -c hash.md5
+
+clean:
+	rm -f $(TARGS) ocean_topog.*.nc

--- a/testing/hash.md5
+++ b/testing/hash.md5
@@ -1,0 +1,1 @@
+hash.md5.gfdl-pan105

--- a/testing/hash.md5.gfdl-pan105
+++ b/testing/hash.md5.gfdl-pan105
@@ -1,0 +1,3 @@
+33b5bbb9ff272e4dcfe469ca871aac7b  ocean_topog.Merc.4deg_r3b1h1.nc
+33b5bbb9ff272e4dcfe469ca871aac7b  ocean_topog.Merc.4deg_r3b2h1.nc
+33b5bbb9ff272e4dcfe469ca871aac7b  ocean_topog.Merc.4deg_r3b4h1.nc


### PR DESCRIPTION
- We are breaking the target grid into blocks in the x (longitude) direction and find the topography for each block separately to be able to run the tool for higher resolution grids which puts stress on the memory of the machineif it's done in one piece.
- It turns out thet the RSC algorithm does not work properly if these blocks are treated totally indepent and they must have some overlap where they join and this causes the results be slightly differnet for different number of blocks. The differencs shows large values at the joint and also noise inside the blocks
- In this update we introduce a 1 cell overlap between the blocks before applying the RSC algorithm on them  and then clear these overlaps when joining the blocks together.
- It remians to prove why these overlaps fix the issue.